### PR TITLE
Add equity research guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-Work in Progress...
+# Equity Research App
+
+This project contains a React (TypeScript) frontend scaffold created with Vite. Backend services are expected to be implemented in Java 21 with Spring Boot.
+
+See [docs/EquityResearchGuide.md](docs/EquityResearchGuide.md) for development steps and best practices.

--- a/docs/EquityResearchGuide.md
+++ b/docs/EquityResearchGuide.md
@@ -1,0 +1,171 @@
+# Equity Research Application Development Guide
+
+This guide outlines recommended steps and code snippets for building a full-stack equity research application using a React (TypeScript) frontend and a Java 21 Spring Boot backend.
+
+## 1. Web Scraping from Financial Sources
+
+> **Disclaimer**
+> Ensure that any web scraping complies with the terms of service of the target websites. Respect rate limits and robots.txt rules. Do not scrape information that you are not legally allowed to access or store.
+
+### Example Approach with Java and Jsoup
+
+```java
+// build.gradle (or pom.xml) should include jsoup dependency
+// implementation 'org.jsoup:jsoup:1.17.2'
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+public class YahooFinanceScraper {
+    public StockData scrape(String symbol) throws IOException {
+        String url = "https://finance.yahoo.com/quote/" + symbol;
+        Document doc = Jsoup.connect(url).get();
+        Element price = doc.selectFirst("fin-streamer[data-field=\"regularMarketPrice\"]");
+        return new StockData(symbol, price.text());
+    }
+}
+```
+
+### Notes
+- Always check the website's robots.txt and terms of service.
+- Cache results and avoid aggressive scraping to respect rate limits.
+- Consider using official APIs where available (e.g., Polygon.io, Alpha Vantage) if the license fits your needs.
+
+## 2. Building Backend APIs with Spring Boot (Java 21)
+
+1. **Set up a Spring Boot project** using `spring-boot-starter-web` and `spring-boot-starter-data-jpa`.
+2. **Define an entity** for storing scraped data in PostgreSQL.
+
+```java
+@Entity
+public class StockData {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String symbol;
+    private BigDecimal price;
+    private Instant retrievedAt;
+    // getters and setters omitted
+}
+```
+
+3. **Create a repository and service** layer to interact with the database.
+
+```java
+@Repository
+public interface StockDataRepository extends JpaRepository<StockData, Long> {
+    Optional<StockData> findTopBySymbolOrderByRetrievedAtDesc(String symbol);
+}
+```
+
+4. **Expose REST endpoints** for retrieving and updating data.
+
+```java
+@RestController
+@RequestMapping("/api/stocks")
+public class StockController {
+    private final StockDataService service;
+    public StockController(StockDataService service) { this.service = service; }
+
+    @GetMapping("/{symbol}")
+    public StockData latest(@PathVariable String symbol) {
+        return service.getLatest(symbol);
+    }
+}
+```
+
+5. **Security**: use Spring Security with JWT for authentication and role-based authorization.
+
+## 3. Creating Reusable Dashboard Components in React + TypeScript
+
+Use component libraries like [Recharts](https://recharts.org/) or [Chart.js](https://www.chartjs.org/).
+
+```tsx
+import { LineChart, Line, XAxis, YAxis, Tooltip } from 'recharts';
+
+interface PricePoint {
+  date: string;
+  close: number;
+}
+
+export const PriceChart: React.FC<{ data: PricePoint[] }> = ({ data }) => (
+  <LineChart width={600} height={300} data={data}>
+    <XAxis dataKey="date" />
+    <YAxis />
+    <Tooltip />
+    <Line type="monotone" dataKey="close" stroke="#8884d8" />
+  </LineChart>
+);
+```
+
+## 4. Integrating AI Models for NLP or Trend Prediction
+
+1. **Choose a library**: for Java, libraries like Deeplearning4j or the TensorFlow Java bindings can be used. Alternatively, run a Python microservice using Hugging Face models.
+2. **Example**: Call a Python service from Java to get sentiment analysis.
+
+```java
+RestTemplate restTemplate = new RestTemplate();
+SentimentResponse resp = restTemplate.postForObject(
+    "http://localhost:5000/analyze", Map.of("text", newsArticle),
+    SentimentResponse.class);
+```
+
+3. **On the Python side** (simplified example):
+
+```python
+from fastapi import FastAPI
+from transformers import pipeline
+
+app = FastAPI()
+classifier = pipeline("sentiment-analysis")
+
+@app.post("/analyze")
+def analyze(item: dict):
+    result = classifier(item["text"])
+    return {"label": result[0]["label"], "score": result[0]["score"]}
+```
+
+## 5. Managing API Rate Limits and Data Freshness
+
+- **Caching**: Store recent results in PostgreSQL or an in-memory store (Redis) to reduce repeated external calls.
+- **Scheduled jobs**: Use Spring's `@Scheduled` tasks to refresh data periodically.
+- **Backoff strategies**: If a third-party service limits requests, implement exponential backoff or respect `Retry-After` headers.
+
+## 6. Deployment Using Docker and Cloud Services
+
+1. **Dockerize the backend**:
+
+```dockerfile
+# Dockerfile
+FROM eclipse-temurin:21-jdk
+WORKDIR /app
+COPY build/libs/app.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]
+```
+
+2. **Dockerize the frontend**:
+
+```dockerfile
+# Dockerfile.frontend
+FROM node:20 as build
+WORKDIR /app
+COPY . .
+RUN npm install && npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+```
+
+3. **Compose** services together and deploy to AWS (e.g., ECS, EKS) or platforms like Render. Use environment variables for database credentials and secrets.
+
+## Additional Best Practices
+
+- **Logging & Monitoring**: integrate tools like Prometheus/Grafana for metrics and centralized logging.
+- **Testing**: write unit and integration tests for both backend and frontend.
+- **CI/CD**: automate builds and deployments with GitHub Actions or GitLab CI.
+
+---
+
+This document provides a high-level overview to kickstart development of the equity research application. Adapt each example to your specific requirements and infrastructure.


### PR DESCRIPTION
## Summary
- add instructions on building a full-stack equity research app
- link to guide in README

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6884c1f68ee88323b04af41f1ce85956